### PR TITLE
backwards compatible with tensorflow

### DIFF
--- a/environment_py310.yml
+++ b/environment_py310.yml
@@ -1,4 +1,4 @@
-name: monte_python
+name: base
 channels:
   - conda-forge
   - defaults

--- a/environment_py38.yml
+++ b/environment_py38.yml
@@ -1,4 +1,4 @@
-name: monte_python
+name: base
 channels:
   - conda-forge
   - defaults

--- a/wofs_ml_severe/__init__.py
+++ b/wofs_ml_severe/__init__.py
@@ -1,4 +1,3 @@
-
 from .io.io import MLDataLoader
 from .data_pipeline.ml_data_generator import MLDataGenerator
 from .data_pipeline.ensemble_track_segmentation import generate_ensemble_track_file 

--- a/wofs_ml_severe/data_pipeline/local_explainer.py
+++ b/wofs_ml_severe/data_pipeline/local_explainer.py
@@ -128,7 +128,7 @@ class LocalExplainer:
     def _shap(self):
 
         shap_kws={'masker' : shap.maskers.Partition(self._X_train, 
-                                                    max_samples=100, 
+                                                    max_samples=25, 
                                                     clustering="correlation"), 
                                                    'algorithm' : 'permutation'}
 

--- a/wofs_ml_severe/data_pipeline/ml_data_generator.py
+++ b/wofs_ml_severe/data_pipeline/ml_data_generator.py
@@ -246,10 +246,13 @@ class MLDataGenerator:
             # Compute the probabilities or hail size.
             # TODO: refactor for the hail regression model.
             if 'Regressor' in model_fname:
-                predictions = model.predict(X)
-                # Temporary fix for negative hail sizes! 
-                predictions[predictions<=0.0] = 0.0
-                hail_size = predictions
+                if model is not None: 
+                    predictions = model.predict(X)
+                    # Temporary fix for negative hail sizes! 
+                    predictions[predictions<=0.0] = 0.0
+                else:
+                    predictions = np.zeros(len(X))
+                hail_size = predictions.copy()                             
             else:
                 predictions = model.predict_proba(X)[:,1]
             
@@ -262,7 +265,7 @@ class MLDataGenerator:
             prediction_data[f'trimmed_tracks'] = (['NY', 'NX'], storm_objects_trimmed)
             
             # Generate the local explainability JSON. 
-            if self.explain:
+            if self.explain and model is not None:
                 explainfile = self.generate_explainability_json(model, X, target, dataframe, features, 
                                      ensemble_track_file, ml_config, hail_size=hail_size, 
                                                                 model_path=self.model_path, 

--- a/wofs_ml_severe/io/load_tf_model.py
+++ b/wofs_ml_severe/io/load_tf_model.py
@@ -4,29 +4,37 @@ sys.path.insert(0, '/home/monte.flora/python_packages/ml_workflow')
 
 
 import joblib
-from tensorflow.keras.models import load_model
-from tensorflow.keras.metrics import RootMeanSquaredError
+try: 
+    from tensorflow.keras.models import load_model
+    from tensorflow.keras.metrics import RootMeanSquaredError
 
-from ml_workflow.custom_losses import (WeightedMSE, 
+    from ml_workflow.custom_losses import (WeightedMSE, 
                                               RegressLogLoss_Normal, 
                                               RegressLogLoss_SinhArcsinh,
                                               CustomHailSizeLoss, 
                                        MyWeightedMSE)
 
-# custom evaluation metrics. 
-from ml_workflow.custom_metrics import (ParaRootMeanSquaredError2, 
+    # custom evaluation metrics. 
+    from ml_workflow.custom_metrics import (ParaRootMeanSquaredError2, 
                                         ConditionalRootMeanSquaredError, 
                                         ConditionalParaRootMeanSquaredError,
                                         CSIScoreThreshold
                                        )
 
-from ml_workflow.tf_pipeline import TensorFlowPipeline
+    from ml_workflow.tf_pipeline import TensorFlowPipeline
+    tensorflow_loaded=True
+except ModuleNotFoundError:
+    print('Tensorflow is not installed... Moving on')
+    tensorflow_loaded=False
 
-def load_tf_model(tf_model_path = '/work/mflora/ML_DATA/NN_MODELS/custom_loss_tune/model_56.h5'):
+if tensorflow_loaded: 
+
     
-    base_path = os.path.dirname(tf_model_path)
+    def load_tf_model(tf_model_path = '/work/mflora/ML_DATA/NN_MODELS/custom_loss_tune/model_56.h5'):
     
-    tf_model = load_model(tf_model_path, custom_objects = 
+        base_path = os.path.dirname(tf_model_path)
+    
+        tf_model = load_model(tf_model_path, custom_objects = 
                               {
                                'RegressLogLoss_SinhArcsinh' : RegressLogLoss_SinhArcsinh,
                                'RegressLogLoss_Normal' : RegressLogLoss_Normal,
@@ -39,11 +47,15 @@ def load_tf_model(tf_model_path = '/work/mflora/ML_DATA/NN_MODELS/custom_loss_tu
                                'CSIScoreThreshold' : CSIScoreThreshold  
                               })
 
-    # This function assumes that the preprocesing sklearn models are available in the same 
-    # directory as the tensorflow model. 
-    names = ['imputer', 'scaler']
-    preprocessors = [joblib.load(os.path.join(base_path, f'{name}.joblib')) 
+        # This function assumes that the preprocesing sklearn models are available in the same 
+        # directory as the tensorflow model. 
+        names = ['imputer', 'scaler']
+        preprocessors = [joblib.load(os.path.join(base_path, f'{name}.joblib')) 
                  for name in names]
-    pipeline = TensorFlowPipeline(tf_model, preprocessors)
+        pipeline = TensorFlowPipeline(tf_model, preprocessors)
     
-    return pipeline 
+        return pipeline 
+    
+else:
+    def load_tf_model(tf_model_path):
+        return None


### PR DESCRIPTION
The code is backward compatible with Python 3.8 without using the TensorFlow hail regression model if Tensorflow can be installed. The predictions are still saved, but all zeros. 